### PR TITLE
#39 fix: slow head rotation when in 30fps

### DIFF
--- a/Assets/Prefabs/NPC.prefab
+++ b/Assets/Prefabs/NPC.prefab
@@ -2094,8 +2094,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   movementDirection: {x: 0, y: 0, z: -1}
   speed: 2
-  headAngle: 128.47
-  headRotationSpeed: 0.02
+  headRotationSpeed: 26.12
 --- !u!1 &6053803975967025998
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NPCMovement.cs
+++ b/Assets/Scripts/NPCMovement.cs
@@ -8,8 +8,6 @@ public class NPCMovement : MonoBehaviour
     public Vector3 movementDirection = Vector3.forward;
     public float speed = -2.0f;
 
-    public float headAngle;
-    
     IAvoider avoiderComponent;
 
     private Quaternion initialHeadRotation;
@@ -102,9 +100,9 @@ public class NPCMovement : MonoBehaviour
 
     void UpdateHeadRotationAngle(Vector3 newEulerAngle) {
         headRotationTarget = new Vector3(
-            Mathf.MoveTowardsAngle(headRotationTarget.x, newEulerAngle.x, headRotationSpeed),
-            Mathf.MoveTowardsAngle(headRotationTarget.y, newEulerAngle.y, headRotationSpeed),
-            Mathf.MoveTowardsAngle(headRotationTarget.z, newEulerAngle.z, headRotationSpeed)
+            Mathf.MoveTowardsAngle(headRotationTarget.x, newEulerAngle.x, headRotationSpeed * Time.deltaTime),
+            Mathf.MoveTowardsAngle(headRotationTarget.y, newEulerAngle.y, headRotationSpeed * Time.deltaTime),
+            Mathf.MoveTowardsAngle(headRotationTarget.z, newEulerAngle.z, headRotationSpeed * Time.deltaTime)
         );
     }
 

--- a/ProjectSettings/TimelineSettings.asset
+++ b/ProjectSettings/TimelineSettings.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a287be6c49135cd4f9b2b8666c39d999, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assetDefaultFramerate: 60


### PR DESCRIPTION
When I tested the game on my MacBook, the game ran at 30fps. This resulted in the head movement of the NPCs turning very slowly. What I did was just to add delta time to the head-turning update